### PR TITLE
Modiy Ex syllable

### DIFF
--- a/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/KanaToRomaji.java
+++ b/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/KanaToRomaji.java
@@ -37,7 +37,7 @@ public class KanaToRomaji {
         } else {
             // 直音
             // 変換音韻の抽出
-            if (system == RomajiSystem.HEPBURN && isMM(kanaStr, index)) {
+            if ((system == RomajiSystem.HEPBURN || system == RomajiSystem.HEPBURN_EXTEND) && isMM(kanaStr, index)) {
                 // ヘボン式に限ったmb,mm,mpの音韻
                 kanaSyllable = kanaStr.substring(index, index + 2);
                 recRomaji.addAll(convertRecursion(kanaStr, index + 2, system));

--- a/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/RomajiConverter.java
+++ b/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/RomajiConverter.java
@@ -7,7 +7,10 @@ public class RomajiConverter {
     public enum RomajiSystem {
         HEPBURN,
         KUNREI,
-        NIHON
+        NIHON,
+        HEPBURN_EXTEND,
+        KUNREI_EXTEND,
+        NIHON_EXTEND
     }
 
     public static List<String> ToRomaji(String kanaStr, RomajiSystem system) {

--- a/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/RomajiToKana.java
+++ b/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/RomajiToKana.java
@@ -15,12 +15,15 @@ public class RomajiToKana {
         if (romajiStr == null || romajiStr.length() == 0) {
             return kanaStrList;
         }
-        kanaStrList = converterRecursion(romajiStr, 0, system);
+        try {
+            kanaStrList = converterRecursion(romajiStr, 0, system);
+        } catch (SyllableException e) {
+        }
 
         return kanaStrList;
     }
 
-    private static List<String> converterRecursion(final String romajiStr, int index, RomajiSystem system) {
+    private static List<String> converterRecursion(final String romajiStr, int index, RomajiSystem system) throws SyllableException {
         List<String> kanaStrList = new ArrayList<>();
         if (romajiStr.length() == index) {
             return kanaStrList;    // Terminate
@@ -52,6 +55,13 @@ public class RomajiToKana {
             }
         }
 
+        if (kanaStrList.isEmpty()) {
+            throw new SyllableException();
+        }
+
         return kanaStrList;
+    }
+
+    private static class SyllableException extends Exception {
     }
 }

--- a/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/Syllable.java
+++ b/romajiconverter/src/main/java/com/ivoryworks/romajiconverter/Syllable.java
@@ -11,7 +11,7 @@ class Syllable {
             "ら", "り", "る", "れ", "ろ", "わ", "ん",
             "が", "ぎ", "ぐ", "げ", "ご", "ざ", "ず", "ぜ", "ぞ",
             "だ", "で", "ど", "ば", "び", "ぶ", "べ", "ぼ",
-            "ぱ", "ぴ", "ぷ", "ぺ", "ぽ", "え", "づ"};
+            "ぱ", "ぴ", "ぷ", "ぺ", "ぽ"};
     // 直音音節(ローマ字)
     private static final String[] CHOKU_ROMAJI_BASE = {"a", "i", "u", "e", "o", "ka", "ki", "ku", "ke", "ko",
             "sa", "su", "se", "so", "ta", "te", "to",
@@ -20,12 +20,23 @@ class Syllable {
             "ra", "ri", "ru", "re", "ro", "wa", "n",
             "ga", "gi", "gu", "ge", "go", "za", "zu", "ze", "zo",
             "da", "de", "do", "ba", "bi", "bu", "be", "bo",
-            "pa", "pi", "pu", "pe", "po", "ye", "dzu"};
+            "pa", "pi", "pu", "pe", "po"};
+    // 直音音節(かな拡張)
+    private static final String[] CHOKU_KANA_BASE_EX = {"え", "づ"};
+    // 直音音節(ローマ字拡張)
+    private static final String[] CHOKU_ROMAJI_BASE_EX = {"ye", "dzu"};
+
     // 直音音節(差分)
-    private static final String[] CHOKU_KANA_DIFF = {"し", "じ", "ち", "つ", "ぢ", "づ", "ふ", "ゐ", "ゑ", "を"};
-    private static final String[] CHOKU_ROMAJI_DIFF_HEPBURN = {"shi", "ji", "chi", "tsu", "ji", "zu", "fu", "i", "e", "o"};
-    private static final String[] CHOKU_ROMAJI_DIFF_KUNREI = {"si", "zi", "ti", "tu", "zi", "zu", "hu", "i", "e", "o"};
-    private static final String[] CHOKU_ROMAJI_DIFF_NIHON = {"si", "zi", "ti", "tu", "di", "du", "hu", "wi", "we", "wo"};
+    private static final String[] CHOKU_KANA_DIFF = {"し", "じ", "ち", "つ", "ぢ", "づ", "ふ", "を"};
+    private static final String[] CHOKU_ROMAJI_DIFF_HEPBURN = {"shi", "ji", "chi", "tsu", "ji", "zu", "fu", "o"};
+    private static final String[] CHOKU_ROMAJI_DIFF_KUNREI = {"si", "zi", "ti", "tu", "zi", "zu", "hu", "o"};
+    private static final String[] CHOKU_ROMAJI_DIFF_NIHON = {"si", "zi", "ti", "tu", "di", "du", "hu", "wo"};
+    // 直音音節(差分拡張)
+    private static final String[] CHOKU_KANA_DIFF_EX = {"ゐ", "ゑ"};
+    private static final String[] CHOKU_ROMAJI_DIFF_HEPBURN_EX = {"i", "e"};
+    private static final String[] CHOKU_ROMAJI_DIFF_KUNREI_EX = {"i", "e"};
+    private static final String[] CHOKU_ROMAJI_DIFF_NIHON_EX = {"wi", "we"};
+
 
     // 拗音音節(かな)
     private static final String[] YOU_KANA_BASE = {"きゃ", "きゅ", "きょ", "にゃ", "にゅ", "にょ",
@@ -92,13 +103,25 @@ class Syllable {
     private static String[] getRomajiChokuSyllable(String key, RomajiSystem system) {
         String[] syllables = getSyllable(CHOKU_KANA_BASE, CHOKU_ROMAJI_BASE, key);
         switch (system) {
+            case HEPBURN_EXTEND:
+                syllables = joinArray(syllables, getSyllable(CHOKU_KANA_BASE_EX, CHOKU_ROMAJI_BASE_EX, key));
+                syllables = joinArray(syllables, getSyllable(CHOKU_KANA_DIFF_EX, CHOKU_ROMAJI_DIFF_HEPBURN_EX, key));
+                // throw
             case HEPBURN:
                 syllables = joinArray(syllables, getSyllable(CHOKU_KANA_DIFF, CHOKU_ROMAJI_DIFF_HEPBURN, key));
                 syllables = joinArray(syllables, getSyllable(MM_KANA_HEPBURN, MM_ROMAJI_HEPBURN, key));
                 break;
+            case KUNREI_EXTEND:
+                syllables = joinArray(syllables, getSyllable(CHOKU_KANA_BASE_EX, CHOKU_ROMAJI_BASE_EX, key));
+                syllables = joinArray(syllables, getSyllable(CHOKU_KANA_DIFF_EX, CHOKU_ROMAJI_DIFF_KUNREI_EX, key));
+                // throw
             case KUNREI:
                 syllables = joinArray(syllables, getSyllable(CHOKU_KANA_DIFF, CHOKU_ROMAJI_DIFF_KUNREI, key));
                 break;
+            case NIHON_EXTEND:
+                syllables = joinArray(syllables, getSyllable(CHOKU_KANA_BASE_EX, CHOKU_ROMAJI_BASE_EX, key));
+                syllables = joinArray(syllables, getSyllable(CHOKU_KANA_DIFF_EX, CHOKU_ROMAJI_DIFF_NIHON_EX, key));
+                // throw
             case NIHON:
                 syllables = joinArray(syllables, getSyllable(CHOKU_KANA_DIFF, CHOKU_ROMAJI_DIFF_NIHON, key));
                 break;
@@ -115,12 +138,18 @@ class Syllable {
     private static String[] getRomajiYouSyllable(String key, RomajiSystem system) {
         String[] syllables = getSyllable(YOU_KANA_BASE, YOU_ROMAJI_BASE, key);
         switch (system) {
+            case HEPBURN_EXTEND:
+                // throw
             case HEPBURN:
                 syllables = joinArray(syllables, getSyllable(YOU_KANA_DIFF, YOU_ROMAJI_DIFF_HEPBURN, key));
                 break;
+            case KUNREI_EXTEND:
+                // throw
             case KUNREI:
                 syllables = joinArray(syllables, getSyllable(YOU_KANA_DIFF, YOU_ROMAJI_DIFF_KUNREI, key));
                 break;
+            case NIHON_EXTEND:
+                // throw
             case NIHON:
                 syllables = joinArray(syllables, getSyllable(YOU_KANA_DIFF, YOU_ROMAJI_DIFF_NIHON, key));
                 break;
@@ -149,13 +178,25 @@ class Syllable {
     private static String[] getKanaChokuSyllable(String key, RomajiSystem system) {
         String[] syllables = getSyllable(CHOKU_ROMAJI_BASE, CHOKU_KANA_BASE, key);
         switch (system) {
+            case HEPBURN_EXTEND:
+                syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_BASE_EX, CHOKU_KANA_BASE_EX, key));
+                syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_DIFF_HEPBURN_EX, CHOKU_KANA_DIFF_EX, key));
+                // throw
             case HEPBURN:
                 syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_DIFF_HEPBURN, CHOKU_KANA_DIFF, key));
                 syllables = joinArray(syllables, getSyllable(MM_ROMAJI_HEPBURN, MM_KANA_HEPBURN, key));
                 break;
+            case KUNREI_EXTEND:
+                syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_BASE_EX, CHOKU_KANA_BASE_EX, key));
+                syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_DIFF_KUNREI_EX, CHOKU_KANA_DIFF_EX, key));
+                // throw
             case KUNREI:
                 syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_DIFF_KUNREI, CHOKU_KANA_DIFF, key));
                 break;
+            case NIHON_EXTEND:
+                syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_BASE_EX, CHOKU_KANA_BASE_EX, key));
+                syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_DIFF_NIHON_EX, CHOKU_KANA_DIFF_EX, key));
+                // throw
             case NIHON:
                 syllables = joinArray(syllables, getSyllable(CHOKU_ROMAJI_DIFF_NIHON, CHOKU_KANA_DIFF, key));
                 break;
@@ -172,12 +213,18 @@ class Syllable {
     private static String[] getKanaYouSyllable(String key, RomajiSystem system) {
         String[] syllables = getSyllable(YOU_ROMAJI_BASE, YOU_KANA_BASE, key);
         switch (system) {
+            case HEPBURN_EXTEND:
+                // throw
             case HEPBURN:
                 syllables = joinArray(syllables, getSyllable(YOU_ROMAJI_DIFF_HEPBURN, YOU_KANA_DIFF, key));
                 break;
+            case KUNREI_EXTEND:
+                // throw
             case KUNREI:
                 syllables = joinArray(syllables, getSyllable(YOU_ROMAJI_DIFF_KUNREI, YOU_KANA_DIFF, key));
                 break;
+            case NIHON_EXTEND:
+                // throw
             case NIHON:
                 syllables = joinArray(syllables, getSyllable(YOU_ROMAJI_DIFF_NIHON, YOU_KANA_DIFF, key));
                 break;

--- a/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/KanaToRomajiTest.java
+++ b/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/KanaToRomajiTest.java
@@ -25,114 +25,37 @@ public class KanaToRomajiTest {
     }
 
     /**
-     * かなtoローマ字 日本式 拗音変換
+     * かなtoローマ字 ヘボン式 直音変換
+     * @throws Exception
      */
     @Test
-    public void convertKana2RomajiNihonYouOn() {
-        // sya,syu,syo
-        assertTrue(convertChecker("しゃしゅしょ", new String[]{"syasyusyo"}, RomajiSystem.NIHON));
+    public void converterKana2RomajiHepburnChokuOn() throws Exception {
+        // shi
+        assertTrue(convertChecker("すし", new String[]{"sushi"}, RomajiSystem.HEPBURN));
 
-        // tya,tyu,tyo
-        assertTrue(convertChecker("ちゃちゅちょ", new String[]{"tyatyutyo"}, RomajiSystem.NIHON));
+        // tsu,chi
+        assertTrue(convertChecker("ちつ", new String[]{"chitsu"}, RomajiSystem.HEPBURN));
 
-        // zya,zyu,zyo
-        assertTrue(convertChecker("じゃじゅじょ", new String[]{"zyazyuzyo"}, RomajiSystem.NIHON));
+        // ji
+        assertTrue(convertChecker("じ", new String[]{"ji"}, RomajiSystem.HEPBURN));
 
-        // dya,dyu,dyo
-        assertTrue(convertChecker("ぢゃぢゅぢょ", new String[]{"dyadyudyo"}, RomajiSystem.NIHON));
-
-        // ssi,zzi.tti.ttu.ddi.ddu,hhu
-        assertTrue(convertChecker("さっし", new String[]{"sassi"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("さっじ", new String[]{"sazzi"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("さっち", new String[]{"satti"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("さっつ", new String[]{"sattu"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("さっぢ", new String[]{"saddi"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("さっづ", new String[]{"saddu"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("さっふ", new String[]{"sahhu"}, RomajiSystem.NIHON));
-
-        // kwa,gwa
-        assertTrue(convertChecker("くゎぐゎ", new String[]{"kwagwa"}, RomajiSystem.NIHON));
-
-        // gunma, nanba
-        assertTrue(convertChecker("ぐんま", new String[]{"gunma"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("なんば", new String[]{"nanba"}, RomajiSystem.NIHON));
+        // ji,zu
+        assertTrue(convertChecker("ぢづ", new String[]{"jizu"}, RomajiSystem.HEPBURN));
     }
 
-    /**
-     * かなtoローマ字 日本式 直音変換
-     */
     @Test
-    public void convertKana2RomajiNihonChokuOn() {
-        // si, zi
-        assertTrue(convertChecker("しじ", new String[]{"sizi"}, RomajiSystem.NIHON));
+    public void converterKana2RomajiHepburnChokuOnEx() throws Exception {
+        // shi
+        assertTrue(convertChecker("すし", new String[]{"sushi"}, RomajiSystem.HEPBURN_EXTEND));
 
-        // ti, tu
-        assertTrue(convertChecker("ちつ", new String[]{"titu"}, RomajiSystem.NIHON));
+        // tsu,chi
+        assertTrue(convertChecker("ちつ", new String[]{"chitsu"}, RomajiSystem.HEPBURN_EXTEND));
 
-        // di, du
-        assertTrue(convertChecker("ぢづ", new String[]{"didzu", "didu"}, RomajiSystem.NIHON));
+        // ji
+        assertTrue(convertChecker("じ", new String[]{"ji"}, RomajiSystem.HEPBURN_EXTEND));
 
-        // hu
-        assertTrue(convertChecker("ふ", new String[]{"hu"}, RomajiSystem.NIHON));
-
-        // wi, we, wo
-        assertTrue(convertChecker("ゐゑを", new String[]{"wiwewo"}, RomajiSystem.NIHON));
-
-        // e. ye
-        assertTrue(convertChecker("え", new String[]{"e", "ye"}, RomajiSystem.NIHON));
-    }
-
-    /**
-     * かなtoローマ字 訓令式 拗音変換
-     */
-    @Test
-    public void convertKana2RomajiKunreiYouOn() {
-        // sya,syu,syo
-        assertTrue(convertChecker("しゃしゅしょ", new String[]{"syasyusyo"}, RomajiSystem.KUNREI));
-
-        // tya,tyu,tyo
-        assertTrue(convertChecker("ちゃちゅちょ", new String[]{"tyatyutyo"}, RomajiSystem.KUNREI));
-
-        // zya,zyu,zyo
-        assertTrue(convertChecker("じゃじゅじょ", new String[]{"zyazyuzyo"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("ぢゃぢゅぢょ", new String[]{"zyazyuzyo"}, RomajiSystem.KUNREI));
-
-        // ssi,zzi,tti,ttu,zzi,zzu,hhu
-        assertTrue(convertChecker("さっし", new String[]{"sassi"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("さっじ", new String[]{"sazzi"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("さっち", new String[]{"satti"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("さっつ", new String[]{"sattu"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("さっぢ", new String[]{"sazzi"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("さっづ", new String[]{"sazzu"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("さっふ", new String[]{"sahhu"}, RomajiSystem.KUNREI));
-
-        // kwa,gwa
-        assertTrue(convertChecker("くゎぐゎ", new String[]{"kwagwa"}, RomajiSystem.KUNREI));
-
-        // gunma, nanba
-        assertTrue(convertChecker("ぐんま", new String[]{"gunma"}, RomajiSystem.KUNREI));
-        assertTrue(convertChecker("なんば", new String[]{"nanba"}, RomajiSystem.KUNREI));
-    }
-
-    /**
-     * かなtoローマ字 訓令式 直音変換
-     */
-    @Test
-    public void convertKana2RomajiKunreiChokuOn() {
-        // si, zi
-        assertTrue(convertChecker("しじ", new String[]{"sizi"}, RomajiSystem.KUNREI));
-
-        // ti, tu
-        assertTrue(convertChecker("ちつ", new String[]{"titu"}, RomajiSystem.KUNREI));
-
-        // di, du
-        assertTrue(convertChecker("ぢづ", new String[]{"zidzu", "zizu"}, RomajiSystem.KUNREI));
-
-        // hu
-        assertTrue(convertChecker("ふ", new String[]{"hu"}, RomajiSystem.KUNREI));
-
-        // wi, we, wo
-        assertTrue(convertChecker("ゐゑを", new String[]{"ieo"}, RomajiSystem.KUNREI));
+        // ji,zu
+        assertTrue(convertChecker("ぢづ", new String[]{"jidzu", "jizu"}, RomajiSystem.HEPBURN_EXTEND));
     }
 
     /**
@@ -168,23 +91,244 @@ public class KanaToRomajiTest {
         assertTrue(convertChecker("なんば", new String[]{"namba", "nanba"}, RomajiSystem.HEPBURN));
     }
 
+    @Test
+    public void converterKana2RomajiHepburnYouOnEx() throws Exception {
+        // sha,shu,sho
+        assertTrue(convertChecker("しゃしゅしょ", new String[]{"shashusho"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // cha,chu,cho
+        assertTrue(convertChecker("ちゃちゅちょ", new String[]{"chachucho"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // ja,ju,jo
+        assertTrue(convertChecker("じゃじゅじょ", new String[]{"jajujo"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("ぢゃぢゅぢょ", new String[]{"jajujo"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // sshi,jji,tchi,ttsu,jji,zzu,ffu
+        assertTrue(convertChecker("さっし", new String[]{"sasshi"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("さっじ", new String[]{"sajji"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("さっち", new String[]{"satchi"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("さっつ", new String[]{"sattsu"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("さっぢ", new String[]{"sajji"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("さっづ", new String[]{"sazzu"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("さっふ", new String[]{"saffu"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // kuwa,guwa
+        assertTrue(convertChecker("くゎぐゎ", new String[]{"kuwaguwa"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // gumma, namba
+        assertTrue(convertChecker("ぐんま", new String[]{"gumma", "gunma"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("なんば", new String[]{"namba", "nanba"}, RomajiSystem.HEPBURN_EXTEND));
+    }
+
     /**
-     * かなtoローマ字 ヘボン式 直音変換
-     * @throws Exception
+     * かなtoローマ字 訓令式 直音変換
      */
     @Test
-    public void converterKana2RomajiHepburnChokuOn() throws Exception {
-        // shi
-        assertTrue(convertChecker("すし", new String[]{"sushi"}, RomajiSystem.HEPBURN));
+    public void convertKana2RomajiKunreiChokuOn() {
+        // si, zi
+        assertTrue(convertChecker("しじ", new String[]{"sizi"}, RomajiSystem.KUNREI));
 
-        // tsu,chi
-        assertTrue(convertChecker("ちつ", new String[]{"chitsu"}, RomajiSystem.HEPBURN));
+        // ti, tu
+        assertTrue(convertChecker("ちつ", new String[]{"titu"}, RomajiSystem.KUNREI));
 
-        // ji
-        assertTrue(convertChecker("じ", new String[]{"ji"}, RomajiSystem.HEPBURN));
+        // di, du
+        assertTrue(convertChecker("ぢづ", new String[]{"zizu"}, RomajiSystem.KUNREI));
 
-        // ji,zu
-        assertTrue(convertChecker("ぢづ", new String[]{"jidzu", "jizu"}, RomajiSystem.HEPBURN));
+        // hu
+        assertTrue(convertChecker("ふ", new String[]{"hu"}, RomajiSystem.KUNREI));
+
+        // o
+        assertTrue(convertChecker("を", new String[]{"o"}, RomajiSystem.KUNREI));
+    }
+
+    @Test
+    public void convertKana2RomajiKunreiChokuOnEx() {
+        // si, zi
+        assertTrue(convertChecker("しじ", new String[]{"sizi"}, RomajiSystem.KUNREI_EXTEND));
+
+        // ti, tu
+        assertTrue(convertChecker("ちつ", new String[]{"titu"}, RomajiSystem.KUNREI_EXTEND));
+
+        // di, du
+        assertTrue(convertChecker("ぢづ", new String[]{"zidzu", "zizu"}, RomajiSystem.KUNREI_EXTEND));
+
+        // hu
+        assertTrue(convertChecker("ふ", new String[]{"hu"}, RomajiSystem.KUNREI_EXTEND));
+
+        // wi, we, wo
+        assertTrue(convertChecker("ゐゑを", new String[]{"ieo"}, RomajiSystem.KUNREI_EXTEND));
+    }
+
+    /**
+     * かなtoローマ字 訓令式 拗音変換
+     */
+    @Test
+    public void convertKana2RomajiKunreiYouOn() {
+        // sya,syu,syo
+        assertTrue(convertChecker("しゃしゅしょ", new String[]{"syasyusyo"}, RomajiSystem.KUNREI));
+
+        // tya,tyu,tyo
+        assertTrue(convertChecker("ちゃちゅちょ", new String[]{"tyatyutyo"}, RomajiSystem.KUNREI));
+
+        // zya,zyu,zyo
+        assertTrue(convertChecker("じゃじゅじょ", new String[]{"zyazyuzyo"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("ぢゃぢゅぢょ", new String[]{"zyazyuzyo"}, RomajiSystem.KUNREI));
+
+        // ssi,zzi,tti,ttu,zzi,zzu,hhu
+        assertTrue(convertChecker("さっし", new String[]{"sassi"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("さっじ", new String[]{"sazzi"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("さっち", new String[]{"satti"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("さっつ", new String[]{"sattu"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("さっぢ", new String[]{"sazzi"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("さっづ", new String[]{"sazzu"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("さっふ", new String[]{"sahhu"}, RomajiSystem.KUNREI));
+
+        // kwa,gwa
+        assertTrue(convertChecker("くゎぐゎ", new String[]{"kwagwa"}, RomajiSystem.KUNREI));
+
+        // gunma, nanba
+        assertTrue(convertChecker("ぐんま", new String[]{"gunma"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("なんば", new String[]{"nanba"}, RomajiSystem.KUNREI));
+    }
+
+    @Test
+    public void convertKana2RomajiKunreiYouOnEx() {
+        // sya,syu,syo
+        assertTrue(convertChecker("しゃしゅしょ", new String[]{"syasyusyo"}, RomajiSystem.KUNREI_EXTEND));
+
+        // tya,tyu,tyo
+        assertTrue(convertChecker("ちゃちゅちょ", new String[]{"tyatyutyo"}, RomajiSystem.KUNREI_EXTEND));
+
+        // zya,zyu,zyo
+        assertTrue(convertChecker("じゃじゅじょ", new String[]{"zyazyuzyo"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("ぢゃぢゅぢょ", new String[]{"zyazyuzyo"}, RomajiSystem.KUNREI_EXTEND));
+
+        // ssi,zzi,tti,ttu,zzi,zzu,hhu
+        assertTrue(convertChecker("さっし", new String[]{"sassi"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("さっじ", new String[]{"sazzi"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("さっち", new String[]{"satti"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("さっつ", new String[]{"sattu"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("さっぢ", new String[]{"sazzi"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("さっづ", new String[]{"sazzu"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("さっふ", new String[]{"sahhu"}, RomajiSystem.KUNREI_EXTEND));
+
+        // kwa,gwa
+        assertTrue(convertChecker("くゎぐゎ", new String[]{"kwagwa"}, RomajiSystem.KUNREI_EXTEND));
+
+        // gunma, nanba
+        assertTrue(convertChecker("ぐんま", new String[]{"gunma"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("なんば", new String[]{"nanba"}, RomajiSystem.KUNREI_EXTEND));
+    }
+
+
+    /**
+     * かなtoローマ字 日本式 直音変換
+     */
+    @Test
+    public void convertKana2RomajiNihonChokuOn() {
+        // si, zi
+        assertTrue(convertChecker("しじ", new String[]{"sizi"}, RomajiSystem.NIHON));
+
+        // ti, tu
+        assertTrue(convertChecker("ちつ", new String[]{"titu"}, RomajiSystem.NIHON));
+
+        // di, du
+        assertTrue(convertChecker("ぢづ", new String[]{"didu"}, RomajiSystem.NIHON));
+
+        // hu
+        assertTrue(convertChecker("ふ", new String[]{"hu"}, RomajiSystem.NIHON));
+
+        // wo
+        assertTrue(convertChecker("を", new String[]{"wo"}, RomajiSystem.NIHON));
+
+        // e
+        assertTrue(convertChecker("え", new String[]{"e"}, RomajiSystem.NIHON));
+    }
+
+    @Test
+    public void convertKana2RomajiNihonChokuOnEx() {
+        // si, zi
+        assertTrue(convertChecker("しじ", new String[]{"sizi"}, RomajiSystem.NIHON_EXTEND));
+
+        // ti, tu
+        assertTrue(convertChecker("ちつ", new String[]{"titu"}, RomajiSystem.NIHON_EXTEND));
+
+        // di, du
+        assertTrue(convertChecker("ぢづ", new String[]{"didzu", "didu"}, RomajiSystem.NIHON_EXTEND));
+
+        // hu
+        assertTrue(convertChecker("ふ", new String[]{"hu"}, RomajiSystem.NIHON_EXTEND));
+
+        // wi, we, wo
+        assertTrue(convertChecker("ゐゑを", new String[]{"wiwewo"}, RomajiSystem.NIHON_EXTEND));
+
+        // e. ye
+        assertTrue(convertChecker("え", new String[]{"e", "ye"}, RomajiSystem.NIHON_EXTEND));
+    }
+
+    /**
+     * かなtoローマ字 日本式 拗音変換
+     */
+    @Test
+    public void convertKana2RomajiNihonYouOn() {
+        // sya,syu,syo
+        assertTrue(convertChecker("しゃしゅしょ", new String[]{"syasyusyo"}, RomajiSystem.NIHON));
+
+        // tya,tyu,tyo
+        assertTrue(convertChecker("ちゃちゅちょ", new String[]{"tyatyutyo"}, RomajiSystem.NIHON));
+
+        // zya,zyu,zyo
+        assertTrue(convertChecker("じゃじゅじょ", new String[]{"zyazyuzyo"}, RomajiSystem.NIHON));
+
+        // dya,dyu,dyo
+        assertTrue(convertChecker("ぢゃぢゅぢょ", new String[]{"dyadyudyo"}, RomajiSystem.NIHON));
+
+        // ssi,zzi.tti.ttu.ddi.ddu,hhu
+        assertTrue(convertChecker("さっし", new String[]{"sassi"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("さっじ", new String[]{"sazzi"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("さっち", new String[]{"satti"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("さっつ", new String[]{"sattu"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("さっぢ", new String[]{"saddi"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("さっづ", new String[]{"saddu"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("さっふ", new String[]{"sahhu"}, RomajiSystem.NIHON));
+
+        // kwa,gwa
+        assertTrue(convertChecker("くゎぐゎ", new String[]{"kwagwa"}, RomajiSystem.NIHON));
+
+        // gunma, nanba
+        assertTrue(convertChecker("ぐんま", new String[]{"gunma"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("なんば", new String[]{"nanba"}, RomajiSystem.NIHON));
+    }
+
+    @Test
+    public void convertKana2RomajiNihonYouOnEx() {
+        // sya,syu,syo
+        assertTrue(convertChecker("しゃしゅしょ", new String[]{"syasyusyo"}, RomajiSystem.NIHON_EXTEND));
+
+        // tya,tyu,tyo
+        assertTrue(convertChecker("ちゃちゅちょ", new String[]{"tyatyutyo"}, RomajiSystem.NIHON_EXTEND));
+
+        // zya,zyu,zyo
+        assertTrue(convertChecker("じゃじゅじょ", new String[]{"zyazyuzyo"}, RomajiSystem.NIHON_EXTEND));
+
+        // dya,dyu,dyo
+        assertTrue(convertChecker("ぢゃぢゅぢょ", new String[]{"dyadyudyo"}, RomajiSystem.NIHON_EXTEND));
+
+        // ssi,zzi.tti.ttu.ddi.ddu,hhu
+        assertTrue(convertChecker("さっし", new String[]{"sassi"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("さっじ", new String[]{"sazzi"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("さっち", new String[]{"satti"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("さっつ", new String[]{"sattu"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("さっぢ", new String[]{"saddi"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("さっづ", new String[]{"saddu"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("さっふ", new String[]{"sahhu"}, RomajiSystem.NIHON_EXTEND));
+
+        // kwa,gwa
+        assertTrue(convertChecker("くゎぐゎ", new String[]{"kwagwa"}, RomajiSystem.NIHON_EXTEND));
+
+        // gunma, nanba
+        assertTrue(convertChecker("ぐんま", new String[]{"gunma"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("なんば", new String[]{"nanba"}, RomajiSystem.NIHON_EXTEND));
     }
 
     private boolean convertChecker(String kana, String[] romajis) {
@@ -204,9 +348,8 @@ public class KanaToRomajiTest {
 
     private boolean convertChecker(String kana, String[] romajis, RomajiSystem system) {
         List<String> result;
-        KanaToRomaji k2r = new KanaToRomaji();
 
-        result = k2r.convert(kana, system);
+        result = RomajiConverter.ToRomaji(kana, system);
         if (result.size() != romajis.length) {
             return false;
         }

--- a/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/RomajiToKanaTest.java
+++ b/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/RomajiToKanaTest.java
@@ -10,12 +10,14 @@ import static junit.framework.Assert.assertTrue;
 public class RomajiToKanaTest {
     @Test
     public void convert() throws Exception {
-        assertTrue(convertChecker("ni", new String[]{"んい", "んゐ", "に"}));
-        assertTrue(convertChecker("irohanihoheto", new String[]{
-                "いろはんいほへと", "いろはんゐほへと", "いろはにほへと",
-                "ゐろはんいほへと", "ゐろはんゐほへと", "ゐろはにほへと"}));
+        assertTrue(convertChecker("ni", new String[]{"んい", "に"}));
+        assertTrue(convertChecker("irohanihoheto", new String[]{"いろはんいほへと", "いろはにほへと",}));
     }
 
+    /**
+     * ローマ字toかな ヘボン式 直音変換
+     * @throws Exception
+     */
     @Test
     public void converterRomaji2KanaHepburnChokuOn() throws Exception {
         // shi
@@ -31,6 +33,25 @@ public class RomajiToKanaTest {
         assertTrue(convertChecker("jizu", new String[]{"じず", "じづ", "ぢず", "ぢづ"}, RomajiSystem.HEPBURN));
     }
 
+    @Test
+    public void converterRomaji2KanaHepburnChokuOnEx() throws Exception {
+        // shi
+        assertTrue(convertChecker("sushi", new String[]{"すし"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // tsu,chi
+        assertTrue(convertChecker("chitsu", new String[]{"ちつ"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // ji
+        assertTrue(convertChecker("ji", new String[]{"じ", "ぢ"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // ji,zu
+        assertTrue(convertChecker("jizu", new String[]{"じず", "じづ", "ぢず", "ぢづ"}, RomajiSystem.HEPBURN_EXTEND));
+    }
+
+    /**
+     * ローマ字toかな ヘボン式 拗音変換
+     * @throws Exception
+     */
     @Test
     public void converterRomaji2KanaHepburnYouOn() throws Exception {
         // sha,shu,sho
@@ -58,6 +79,36 @@ public class RomajiToKanaTest {
     }
 
     @Test
+    public void converterRomaji2KanaHepburnYouOnEx() throws Exception {
+        // sha,shu,sho
+        assertTrue(convertChecker("shashusho", new String[]{"しゃしゅしょ"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // cha,chu,cho
+        assertTrue(convertChecker("chachucho", new String[]{"ちゃちゅちょ"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // ja,ju,jo
+        assertTrue(convertChecker("jajujo", new String[]{"じゃじゅじょ", "じゃじゅぢょ", "じゃぢゅじょ", "じゃぢゅぢょ",
+                "ぢゃじゅじょ", "ぢゃじゅぢょ", "ぢゃぢゅじょ", "ぢゃぢゅぢょ"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // sshi,jji,tchi,ttsu,jji,zzu,ffu
+        assertTrue(convertChecker("sasshi", new String[]{"さっし"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("sajji", new String[]{"さっじ", "さっぢ"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("satchi", new String[]{"さっち"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("sattsu", new String[]{"さっつ"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("sajji", new String[]{"さっじ", "さっぢ"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("sazzu", new String[]{"さっず", "さっづ"}, RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(convertChecker("saffu", new String[]{"さっふ"}, RomajiSystem.HEPBURN_EXTEND));
+
+        // gumma, namba
+        assertTrue(convertChecker("gumma", new String[]{"ぐんま", "ぐっま"}, RomajiSystem.HEPBURN_EXTEND));   // ToDo
+        assertTrue(convertChecker("namba", new String[]{"んあんば", "なんば"}, RomajiSystem.HEPBURN_EXTEND));  // ToDO
+    }
+
+    /**
+     * ローマ字toかな 訓令式 直音変換
+     * @throws Exception
+     */
+    @Test
     public void converterRomaji2KanaKunreiChokuOn() throws Exception {
         // si, zi
         assertTrue(convertChecker("sizi", new String[]{"しじ", "しぢ"}, RomajiSystem.KUNREI));
@@ -66,12 +117,31 @@ public class RomajiToKanaTest {
         assertTrue(convertChecker("titu", new String[]{"ちつ"}, RomajiSystem.KUNREI));
 
         // di, du
-        assertTrue(convertChecker("zidzu", new String[]{"じづ", "ぢづ"}, RomajiSystem.KUNREI));
+        assertTrue(convertChecker("zidzu", new String[]{}, RomajiSystem.KUNREI));
 
         // hu
         assertTrue(convertChecker("hu", new String[]{"ふ"}, RomajiSystem.KUNREI));
     }
 
+    @Test
+    public void converterRomaji2KanaKunreiChokuOnEx() throws Exception {
+        // si, zi
+        assertTrue(convertChecker("sizi", new String[]{"しじ", "しぢ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // ti, tu
+        assertTrue(convertChecker("titu", new String[]{"ちつ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // di, du
+        assertTrue(convertChecker("zidzu", new String[]{"じづ", "ぢづ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // hu
+        assertTrue(convertChecker("hu", new String[]{"ふ"}, RomajiSystem.KUNREI_EXTEND));
+    }
+
+    /**
+     * ローマ字toかな 訓令式 拗音変換
+     * @throws Exception
+     */
     @Test
     public void converterRomaji2KanaKunreiYouOn() throws Exception {
         // sya,syu,syo
@@ -101,6 +171,38 @@ public class RomajiToKanaTest {
     }
 
     @Test
+    public void converterRomaji2KanaKunreiYouOnEx() throws Exception {
+        // sya,syu,syo
+        assertTrue(convertChecker("syasyusyo", new String[]{"しゃしゅしょ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // tya,tyu,tyo
+        assertTrue(convertChecker("tyatyutyo", new String[]{"ちゃちゅちょ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // zya,zyu,zyo
+        assertTrue(convertChecker("zyazyuzyo", new String[]{"じゃじゅじょ", "じゃじゅぢょ", "じゃぢゅじょ", "じゃぢゅぢょ",
+                "ぢゃじゅじょ", "ぢゃじゅぢょ", "ぢゃぢゅじょ", "ぢゃぢゅぢょ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // ssi,zzi,tti,ttu,zzi,zzu,hhu
+        assertTrue(convertChecker("sassi", new String[]{"さっし"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("sazzi", new String[]{"さっじ", "さっぢ"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("satti", new String[]{"さっち"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("sattu", new String[]{"さっつ"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("sazzu", new String[]{"さっず", "さっづ"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("sahhu", new String[]{"さっふ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // kwa,gwa
+        assertTrue(convertChecker("kwagwa", new String[]{"くゎぐゎ"}, RomajiSystem.KUNREI_EXTEND));
+
+        // gunma, nanba
+        assertTrue(convertChecker("gunma", new String[]{"ぐんま"}, RomajiSystem.KUNREI_EXTEND));
+        assertTrue(convertChecker("nanba", new String[]{"んあんば", "なんば"}, RomajiSystem.KUNREI_EXTEND));
+    }
+
+    /**
+     * ローマ字toかな 日本式 直音変換
+     * @throws Exception
+     */
+    @Test
     public void converterRomaji2KanaNihonChokuOn() throws Exception {
         // si, zi
         assertTrue(convertChecker("sizi", new String[]{"しじ"}, RomajiSystem.NIHON));
@@ -109,20 +211,47 @@ public class RomajiToKanaTest {
         assertTrue(convertChecker("titu", new String[]{"ちつ"}, RomajiSystem.NIHON));
 
         // di, du
-        assertTrue(convertChecker("didzu", new String[]{"ぢづ"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("didzu", new String[]{}, RomajiSystem.NIHON));
         assertTrue(convertChecker("didu", new String[]{"ぢづ"}, RomajiSystem.NIHON));
 
         // hu
         assertTrue(convertChecker("hu", new String[]{"ふ"}, RomajiSystem.NIHON));
 
         // wi, we, wo
-        assertTrue(convertChecker("wiwewo", new String[]{"ゐゑを"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("wo", new String[]{"を"}, RomajiSystem.NIHON));
 
         // e. ye
         assertTrue(convertChecker("e", new String[]{"え"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("ye", new String[]{"え"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("ye", new String[]{}, RomajiSystem.NIHON));
     }
 
+    @Test
+    public void converterRomaji2KanaNihonChokuOnEx() throws Exception {
+        // si, zi
+        assertTrue(convertChecker("sizi", new String[]{"しじ"}, RomajiSystem.NIHON_EXTEND));
+
+        // ti, tu
+        assertTrue(convertChecker("titu", new String[]{"ちつ"}, RomajiSystem.NIHON_EXTEND));
+
+        // di, du
+        assertTrue(convertChecker("didzu", new String[]{"ぢづ"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("didu", new String[]{"ぢづ"}, RomajiSystem.NIHON_EXTEND));
+
+        // hu
+        assertTrue(convertChecker("hu", new String[]{"ふ"}, RomajiSystem.NIHON_EXTEND));
+
+        // wi, we, wo
+        assertTrue(convertChecker("wiwewo", new String[]{"ゐゑを"}, RomajiSystem.NIHON_EXTEND));
+
+        // e. ye
+        assertTrue(convertChecker("e", new String[]{"え"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("ye", new String[]{"え"}, RomajiSystem.NIHON_EXTEND));
+    }
+
+    /**
+     * ローマ字toかな 日本式 拗音変換
+     * @throws Exception
+     */
     @Test
     public void converterRomaji2KanaNihonYouOn() throws Exception {
         // sya,syu,syo
@@ -147,11 +276,42 @@ public class RomajiToKanaTest {
         assertTrue(convertChecker("sahhu", new String[]{"さっふ"}, RomajiSystem.NIHON));
 
         // kwa,gwa
-        assertTrue(convertChecker("kwagwa", new String[]{"くゎぐゎ"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("kwagwa", new String[]{"くゎぐゎ"}, RomajiSystem.NIHON_EXTEND));
 
         // gunma, nanba
-        assertTrue(convertChecker("gunma", new String[]{"ぐんま"}, RomajiSystem.NIHON));
-        assertTrue(convertChecker("nanba", new String[]{"んあんば", "なんば"}, RomajiSystem.NIHON));
+        assertTrue(convertChecker("gunma", new String[]{"ぐんま"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("nanba", new String[]{"んあんば", "なんば"}, RomajiSystem.NIHON_EXTEND));
+    }
+
+    @Test
+    public void converterRomaji2KanaNihonYouOnEx() throws Exception {
+        // sya,syu,syo
+        assertTrue(convertChecker("syasyusyo", new String[]{"しゃしゅしょ"}, RomajiSystem.NIHON_EXTEND));
+
+        // tya,tyu,tyo
+        assertTrue(convertChecker("tyatyutyo", new String[]{"ちゃちゅちょ"}, RomajiSystem.NIHON_EXTEND));
+
+        // zya,zyu,zyo
+        assertTrue(convertChecker("zyazyuzyo", new String[]{"じゃじゅじょ"}, RomajiSystem.NIHON_EXTEND));
+
+        // dya,dyu,dyo
+        assertTrue(convertChecker("dyadyudyo", new String[]{"ぢゃぢゅぢょ"}, RomajiSystem.NIHON_EXTEND));
+
+        // ssi,zzi.tti.ttu.ddi.ddu,hhu
+        assertTrue(convertChecker("sassi", new String[]{"さっし"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("sazzi", new String[]{"さっじ"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("satti", new String[]{"さっち"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("sattu", new String[]{"さっつ"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("saddi", new String[]{"さっぢ"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("saddu", new String[]{"さっづ"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("sahhu", new String[]{"さっふ"}, RomajiSystem.NIHON_EXTEND));
+
+        // kwa,gwa
+        assertTrue(convertChecker("kwagwa", new String[]{"くゎぐゎ"}, RomajiSystem.NIHON_EXTEND));
+
+        // gunma, nanba
+        assertTrue(convertChecker("gunma", new String[]{"ぐんま"}, RomajiSystem.NIHON_EXTEND));
+        assertTrue(convertChecker("nanba", new String[]{"んあんば", "なんば"}, RomajiSystem.NIHON_EXTEND));
     }
 
     private boolean convertChecker(String romaji, String[] kanas) {

--- a/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/SyllableTest.java
+++ b/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/SyllableTest.java
@@ -12,6 +12,13 @@ public class SyllableTest {
     @Test
     public void getKanaSyllable() throws Exception {
         String[] outputArray = Syllable.getKanaSyllable("i", RomajiSystem.HEPBURN);
+        assertTrue(outputArray.length == 1);
+        assertEquals(outputArray[0], "い");
+    }
+
+    @Test
+    public void getKanaSyllableEx() throws Exception {
+        String[] outputArray = Syllable.getKanaSyllable("i", RomajiSystem.HEPBURN_EXTEND);
         assertTrue(outputArray.length == 2);
         assertEquals(outputArray[0], "い");
         assertEquals(outputArray[1], "ゐ");
@@ -26,12 +33,30 @@ public class SyllableTest {
 
         // BASEで2つ検出されるケース
         outputArray = Syllable.getRomajiSyllable("え", RomajiSystem.HEPBURN);
+        assertTrue(outputArray.length == 1);
+        assertEquals(outputArray[0], "e");
+
+        // BASEとDIFFで1つずつ検出されるケース
+        outputArray = Syllable.getRomajiSyllable("づ", RomajiSystem.HEPBURN);
+        assertTrue(outputArray.length == 1);
+        assertEquals(outputArray[1], "zu");
+    }
+
+    @Test
+    public void getRomajiSyllableEx() throws Exception {
+        // BASEで1つ検出されるケース
+        String[] outputArray = Syllable.getRomajiSyllable("あ", RomajiSystem.HEPBURN_EXTEND);
+        assertTrue(outputArray.length == 1);
+        assertEquals(outputArray[0], "a");
+
+        // BASEで2つ検出されるケース
+        outputArray = Syllable.getRomajiSyllable("え", RomajiSystem.HEPBURN_EXTEND);
         assertTrue(outputArray.length == 2);
         assertEquals(outputArray[0], "e");
         assertEquals(outputArray[1], "ye");
 
         // BASEとDIFFで1つずつ検出されるケース
-        outputArray = Syllable.getRomajiSyllable("づ", RomajiSystem.HEPBURN);
+        outputArray = Syllable.getRomajiSyllable("づ", RomajiSystem.HEPBURN_EXTEND);
         assertTrue(outputArray.length == 2);
         assertEquals(outputArray[0], "dzu");
         assertEquals(outputArray[1], "zu");
@@ -42,6 +67,32 @@ public class SyllableTest {
         Field chokuKanaBase = Syllable.class.getDeclaredField("CHOKU_KANA_BASE");
         chokuKanaBase.setAccessible(true);
         Field chokuRomajiBase = Syllable.class.getDeclaredField("CHOKU_ROMAJI_BASE");
+        chokuRomajiBase.setAccessible(true);
+
+        Method getSyllable = Syllable.class.getDeclaredMethod("getSyllable", String[].class, String[].class, String.class);
+        getSyllable.setAccessible(true);
+
+        String[] outputArray = (String[]) getSyllable.invoke(null, chokuKanaBase.get(null), chokuRomajiBase.get(null), "あ");
+        assertTrue(outputArray.length == 1);
+        assertEquals(outputArray[0], "a");
+
+        outputArray = (String[]) getSyllable.invoke(null, chokuKanaBase.get(null), chokuRomajiBase.get(null), "え");
+        assertTrue(outputArray.length == 1);
+        assertEquals(outputArray[0], "e");
+
+        outputArray = (String[]) getSyllable.invoke(null, chokuRomajiBase.get(null), chokuKanaBase.get(null), "ka");
+        assertTrue(outputArray.length == 1);
+        assertEquals(outputArray[0], "か");
+
+        outputArray = (String[]) getSyllable.invoke(null, chokuRomajiBase.get(null), chokuKanaBase.get(null), "dzu");
+        assertTrue(outputArray.length == 0);
+    }
+
+    @Test
+    public void getSyllablePrivateEx() throws Exception {
+        Field chokuKanaBase = Syllable.class.getDeclaredField("CHOKU_KANA_BASE_EX");
+        chokuKanaBase.setAccessible(true);
+        Field chokuRomajiBase = Syllable.class.getDeclaredField("CHOKU_ROMAJI_BASE_EX");
         chokuRomajiBase.setAccessible(true);
 
         Method getSyllable = Syllable.class.getDeclaredMethod("getSyllable", String[].class, String[].class, String.class);
@@ -78,6 +129,18 @@ public class SyllableTest {
     }
 
     @Test
+    public void isRomajiChokuSyllableEx() {
+        assertTrue(Syllable.isRomajiChokuSyllable("shi", RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(Syllable.isRomajiChokuSyllable("ji", RomajiSystem.HEPBURN_EXTEND));
+
+        assertTrue(Syllable.isRomajiChokuSyllable("zi", RomajiSystem.KUNREI_EXTEND));
+        assertTrue(Syllable.isRomajiChokuSyllable("hu", RomajiSystem.KUNREI_EXTEND));
+
+        assertTrue(Syllable.isRomajiChokuSyllable("di", RomajiSystem.NIHON_EXTEND));
+        assertTrue(Syllable.isRomajiChokuSyllable("wo", RomajiSystem.NIHON_EXTEND));
+    }
+
+    @Test
     public void isRomajiYouSyllable() {
         assertTrue(Syllable.isRomajiYouSyllable("cha", RomajiSystem.HEPBURN));
         assertTrue(Syllable.isRomajiYouSyllable("jo", RomajiSystem.HEPBURN));
@@ -87,6 +150,18 @@ public class SyllableTest {
 
         assertTrue(Syllable.isRomajiYouSyllable("dya", RomajiSystem.NIHON));
         assertTrue(Syllable.isRomajiYouSyllable("ddi", RomajiSystem.NIHON));
+    }
+
+    @Test
+    public void isRomajiYouSyllableEx() {
+        assertTrue(Syllable.isRomajiYouSyllable("cha", RomajiSystem.HEPBURN_EXTEND));
+        assertTrue(Syllable.isRomajiYouSyllable("jo", RomajiSystem.HEPBURN_EXTEND));
+
+        assertTrue(Syllable.isRomajiYouSyllable("zyo", RomajiSystem.KUNREI_EXTEND));
+        assertTrue(Syllable.isRomajiYouSyllable("zzi", RomajiSystem.KUNREI_EXTEND));
+
+        assertTrue(Syllable.isRomajiYouSyllable("dya", RomajiSystem.NIHON_EXTEND));
+        assertTrue(Syllable.isRomajiYouSyllable("ddi", RomajiSystem.NIHON_EXTEND));
     }
 
     @Test

--- a/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/SyllableTest.java
+++ b/romajiconverter/src/test/java/com/ivoryworks/romajiconverter/SyllableTest.java
@@ -39,7 +39,7 @@ public class SyllableTest {
         // BASEとDIFFで1つずつ検出されるケース
         outputArray = Syllable.getRomajiSyllable("づ", RomajiSystem.HEPBURN);
         assertTrue(outputArray.length == 1);
-        assertEquals(outputArray[1], "zu");
+        assertEquals(outputArray[0], "zu");
     }
 
     @Test
@@ -90,28 +90,25 @@ public class SyllableTest {
 
     @Test
     public void getSyllablePrivateEx() throws Exception {
-        Field chokuKanaBase = Syllable.class.getDeclaredField("CHOKU_KANA_BASE_EX");
-        chokuKanaBase.setAccessible(true);
-        Field chokuRomajiBase = Syllable.class.getDeclaredField("CHOKU_ROMAJI_BASE_EX");
-        chokuRomajiBase.setAccessible(true);
+        Field chokuKanaBaseEx = Syllable.class.getDeclaredField("CHOKU_KANA_BASE_EX");
+        chokuKanaBaseEx.setAccessible(true);
+        Field chokuRomajiBaseEx = Syllable.class.getDeclaredField("CHOKU_ROMAJI_BASE_EX");
+        chokuRomajiBaseEx.setAccessible(true);
 
         Method getSyllable = Syllable.class.getDeclaredMethod("getSyllable", String[].class, String[].class, String.class);
         getSyllable.setAccessible(true);
 
-        String[] outputArray = (String[]) getSyllable.invoke(null, chokuKanaBase.get(null), chokuRomajiBase.get(null), "あ");
+        String[] outputArray = (String[]) getSyllable.invoke(null, chokuKanaBaseEx.get(null), chokuRomajiBaseEx.get(null), "あ");
+        assertTrue(outputArray.length == 0);
+
+        outputArray = (String[]) getSyllable.invoke(null, chokuKanaBaseEx.get(null), chokuRomajiBaseEx.get(null), "え");
         assertTrue(outputArray.length == 1);
-        assertEquals(outputArray[0], "a");
+        assertEquals(outputArray[0], "ye");
 
-        outputArray = (String[]) getSyllable.invoke(null, chokuKanaBase.get(null), chokuRomajiBase.get(null), "え");
-        assertTrue(outputArray.length == 2);
-        assertEquals(outputArray[0], "e");
-        assertEquals(outputArray[1], "ye");
+        outputArray = (String[]) getSyllable.invoke(null, chokuRomajiBaseEx.get(null), chokuKanaBaseEx.get(null), "ka");
+        assertTrue(outputArray.length == 0);
 
-        outputArray = (String[]) getSyllable.invoke(null, chokuRomajiBase.get(null), chokuKanaBase.get(null), "ka");
-        assertTrue(outputArray.length == 1);
-        assertEquals(outputArray[0], "か");
-
-        outputArray = (String[]) getSyllable.invoke(null, chokuRomajiBase.get(null), chokuKanaBase.get(null), "dzu");
+        outputArray = (String[]) getSyllable.invoke(null, chokuRomajiBaseEx.get(null), chokuKanaBaseEx.get(null), "dzu");
         assertTrue(outputArray.length == 1);
         assertEquals(outputArray[0], "づ");
     }


### PR DESCRIPTION
* ゐ、ゑの旧字はオプション指定時(HEPBURN_EXTEND, KUNREI_EXTEND, NIHON_EXTEND)にのみ変換されるように対応。
* え、をyeとして扱うのはオプション指定時のみとする。
* づ、をdzuとして扱うのはオプション指定時のみとする。